### PR TITLE
Fix typo in tails notebook

### DIFF
--- a/docs/gallery/plot_extrap_period.ipynb
+++ b/docs/gallery/plot_extrap_period.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "tri = cl.load_sample('clrd').groupby('LOB').sum().loc['medmal', 'CumPaidLoss']\n",
     "\n",
-    "# Create a fuction to grab the scalar tail value.\n",
+    "# Create a function to grab the scalar tail value.\n",
     "def scoring(model):\n",
     "    \"\"\" Scoring functions must return a scalar \"\"\"\n",
     "    return model.tail_.iloc[0, 0]\n",

--- a/docs/user_guide/tails.ipynb
+++ b/docs/user_guide/tails.ipynb
@@ -845,7 +845,7 @@
    "source": [
     "tri = cl.load_sample('clrd').groupby('LOB').sum().loc['medmal', 'CumPaidLoss']\n",
     "\n",
-    "# Create a fuction to grab the scalar tail value.\n",
+    "# Create a function to grab the scalar tail value.\n",
     "def scoring(model):\n",
     "    \"\"\" Scoring functions must return a scalar \"\"\"\n",
     "    return model.tail_.iloc[0, 0]\n",


### PR DESCRIPTION
## Summary
- correct spelling of 'function' in tails.ipynb
- same typo fix in plot_extrap_period.ipynb

## Testing
- `grep -n "function" docs/user_guide/tails.ipynb`
- `grep -n "function" docs/gallery/plot_extrap_period.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_6841d0354e408328bb0007e28b908071