### PR TITLE
Fix typo in Chainladder docstring

### DIFF
--- a/chainladder/methods/chainladder.py
+++ b/chainladder/methods/chainladder.py
@@ -6,7 +6,7 @@ from chainladder.methods import MethodBase
 
 class Chainladder(MethodBase):
     """
-    The basic determinsitic chainladder method.
+    The basic deterministic chainladder method.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- correct a typo in the Chainladder class docstring

## Testing
- `jb build docs/` *(fails: Could not import extension numpydoc / fails due to Sphinx errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841d1ec1f808328b412a51bfbecd78e